### PR TITLE
Improve synthetic home with simpler home format

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,7 @@ level values.
   device_info:
     manufacturer: Nest
     sw_version: 1.0.0
-  restorable_attribute_keys:
-    - warm_and_cooling
+  device_state: cooling
 ```
 
 ### Restorable Attributes using service calls

--- a/custom_components/synthetic_home/__init__.py
+++ b/custom_components/synthetic_home/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import area_registry as ar, device_registry as dr
 
-from .const import DOMAIN, CONF_FILENAME, DATA_RESTORABLE_ATTRIBUTES
+from .const import DOMAIN, CONF_FILENAME, DATA_DEVICE_STATES
 from .model import parse_home_config
 from .services import async_register_services
 
@@ -40,10 +40,10 @@ PLATFORMS: list[Platform] = [
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault(DATA_RESTORABLE_ATTRIBUTES, {})
+    hass.data[DOMAIN].setdefault(DATA_DEVICE_STATES, {})
 
     config_file = pathlib.Path(hass.config.path(entry.data[CONF_FILENAME]))
-    states = hass.data[DOMAIN][DATA_RESTORABLE_ATTRIBUTES].get(entry.entry_id)
+    states = hass.data[DOMAIN][DATA_DEVICE_STATES].get(entry.entry_id)
     try:
         synthetic_home = parse_home_config(config_file, states)
     except SyntheticHomeError as err:

--- a/custom_components/synthetic_home/binary_sensor.py
+++ b/custom_components/synthetic_home/binary_sensor.py
@@ -1,10 +1,11 @@
 """Binary sensor platform for Synthetic Home."""
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass,
-    BinarySensorEntityDescription,
     DOMAIN as BINARY_SENSOR_DOMAIN,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -14,42 +15,7 @@ from .const import DOMAIN
 from .model import ParsedDevice
 from .entity import SyntheticDeviceEntity
 
-
-BINARY_SENSORS: tuple[BinarySensorEntityDescription, ...] = (
-    BinarySensorEntityDescription(
-        key="lock",
-        device_class=BinarySensorDeviceClass.LOCK,
-    ),
-    BinarySensorEntityDescription(
-        key="door",
-        device_class=BinarySensorDeviceClass.DOOR,
-    ),
-    BinarySensorEntityDescription(
-        key="window",
-        device_class=BinarySensorDeviceClass.WINDOW,
-    ),
-    BinarySensorEntityDescription(
-        key="tamper",
-        device_class=BinarySensorDeviceClass.TAMPER,
-    ),
-    BinarySensorEntityDescription(
-        key="battery",
-        device_class=BinarySensorDeviceClass.BATTERY,
-    ),
-    BinarySensorEntityDescription(
-        key="motion",
-        device_class=BinarySensorDeviceClass.MOTION,
-    ),
-    BinarySensorEntityDescription(
-        key="person",
-        device_class=BinarySensorDeviceClass.OCCUPANCY,
-    ),
-    BinarySensorEntityDescription(
-        key="sound",
-        device_class=BinarySensorDeviceClass.SOUND,
-    ),
-)
-SENSOR_MAP = {desc.key: desc for desc in BINARY_SENSORS}
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -58,11 +24,12 @@ async def async_setup_entry(
     """Set up binary_sensor platform."""
 
     synthetic_home = hass.data[DOMAIN][entry.entry_id]
+    for device in synthetic_home.devices:
+        for entity in device.entities:
+            _LOGGER.debug(entity)
 
     async_add_devices(
-        SyntheticHomeBinarySensor(
-            device, SENSOR_MAP[entity.entity_key], **entity.attributes
-        )
+        SyntheticHomeBinarySensor(device, entity.entity_key, **entity.attributes)
         for device in synthetic_home.devices
         for entity in device.entities
         if entity.platform == BINARY_SENSOR_DOMAIN
@@ -75,13 +42,13 @@ class SyntheticHomeBinarySensor(SyntheticDeviceEntity, BinarySensorEntity):
     def __init__(
         self,
         device: ParsedDevice,
-        entity_desc: BinarySensorEntityDescription,
-        *,
-        is_on: bool = False,
+        key: str,
+        device_class: BinarySensorDeviceClass | None = None,
+        state: bool = False,
     ) -> None:
         """Initialize SyntheticHomeSensor."""
-        super().__init__(device, entity_desc.key)
-        if entity_desc.key not in device.friendly_name.lower():  # Avoid "Motion Motion"
-            self._attr_name = entity_desc.key.capitalize()
-        self.entity_description = entity_desc
-        self._attr_is_on = is_on
+        super().__init__(device, key)
+        if key not in device.friendly_name.lower():  # Avoid "Motion Motion"
+            self._attr_name = key.capitalize()
+        self._attr_device_class = device_class
+        self._attr_is_on = state

--- a/custom_components/synthetic_home/const.py
+++ b/custom_components/synthetic_home/const.py
@@ -6,9 +6,9 @@ CONF_FILENAME = "config_filename"
 
 # Used for loading initial state of an entity and it persists across config
 # entry reloads. Updated with service calls.
-DATA_RESTORABLE_ATTRIBUTES = "restorable_attributes"
+DATA_DEVICE_STATES = "device_states"
 
 ATTR_AREA_NAME = "area"
 ATTR_DEVICE_NAME = "device"
-ATTR_RESTORABLE_ATTRIBUTES_KEY = "restorable_attribute_key"
+ATTR_DEVICE_STATE_KEY = "device_state_key"
 ATTR_CONFIG_ENTRY_ID = "config_entry_id"

--- a/custom_components/synthetic_home/light.py
+++ b/custom_components/synthetic_home/light.py
@@ -1,7 +1,6 @@
 """Light platform for Synthetic Home."""
 
 import logging
-from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -11,7 +10,6 @@ from homeassistant.components.light import (
     ColorMode,
     ATTR_BRIGHTNESS,
     ATTR_RGBW_COLOR,
-    LightEntityDescription,
     DOMAIN as LIGHT_DOMAIN,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -23,36 +21,6 @@ from .model import ParsedDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
-class SyntheticLightEntityDescription(LightEntityDescription):
-    """Entity description for a light."""
-
-    supported_color_modes: set[ColorMode] | None = None
-    color_mode: ColorMode | None = None
-    brightness: int | None = None
-    rgbw_color: tuple[int, int, int, int] | None = None
-
-
-LIGHTS: tuple[SyntheticLightEntityDescription, ...] = (
-    SyntheticLightEntityDescription(
-        key="light-dimmable",
-        supported_color_modes={ColorMode.BRIGHTNESS},
-        color_mode=ColorMode.BRIGHTNESS,
-    ),
-    SyntheticLightEntityDescription(
-        key="light",
-        supported_color_modes={ColorMode.ONOFF},
-        color_mode=ColorMode.ONOFF,
-    ),
-    SyntheticLightEntityDescription(
-        key="light-rgbw",
-        supported_color_modes={ColorMode.RGBW},
-        color_mode=ColorMode.RGBW,
-    ),
-)
-LIGHT_MAP = {desc.key: desc for desc in LIGHTS}
-
-
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
 ) -> None:
@@ -60,7 +28,7 @@ async def async_setup_entry(
     synthetic_home = hass.data[DOMAIN][entry.entry_id]
 
     async_add_devices(
-        SyntheticHomeLight(device, LIGHT_MAP[entity.entity_key], **entity.attributes)
+        SyntheticHomeLight(device, entity.entity_key, **entity.attributes)
         for device in synthetic_home.devices
         for entity in device.entities
         if entity.platform == LIGHT_DOMAIN
@@ -73,20 +41,21 @@ class SyntheticHomeLight(SyntheticDeviceEntity, LightEntity):
     def __init__(
         self,
         device: ParsedDevice,
-        entity_desc: SyntheticLightEntityDescription,
+        key: str,
+        supported_color_modes: set[ColorMode] | None = None,
+        color_mode: ColorMode | None = None,
         *,
         state: str | None = None,
         brightness: int | None = None,
         rgbw_color: tuple[int, int, int, int] | None = None,
     ) -> None:
         """Initialize the device."""
-        super().__init__(device, entity_desc.key)
-        self.entity_description = entity_desc
-        self._attr_supported_color_modes = entity_desc.supported_color_modes
+        super().__init__(device, key)
+        self._attr_supported_color_modes = supported_color_modes
         self._attr_is_on = state is not None and state == "on"
         if brightness is not None and brightness > 0:
             self._attr_is_on = True
-        self._attr_color_mode = entity_desc.color_mode
+        self._attr_color_mode = color_mode
         self._attr_brightness = brightness
         self._attr_rgbw_color = rgbw_color
 

--- a/custom_components/synthetic_home/manifest.json
+++ b/custom_components/synthetic_home/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/allenporter/home-assistant-synthetic-home/issues",
   "requirements": ["synthetic-home==0.1.0"],
-  "version": "1.0.0"
+  "version": "2.0.0"
 }

--- a/custom_components/synthetic_home/manifest.json
+++ b/custom_components/synthetic_home/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/allenporter/home-assistant-synthetic-home/issues",
   "requirements": ["synthetic-home==0.1.0"],
-  "version": "2.0.0"
+  "version": "2.0.1"
 }

--- a/custom_components/synthetic_home/sensor.py
+++ b/custom_components/synthetic_home/sensor.py
@@ -5,14 +5,12 @@ import logging
 from homeassistant.components.sensor import (
     SensorEntity,
     SensorDeviceClass,
-    SensorEntityDescription,
     SensorStateClass,
     StateType,
     DOMAIN as SENSOR_DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.const import PERCENTAGE, UnitOfTemperature, UnitOfEnergy
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -22,50 +20,6 @@ from .entity import SyntheticDeviceEntity
 _LOGGER = logging.getLogger(__name__)
 
 
-class SyntheticSensorEntityDescription(SensorEntityDescription, frozen_or_thawed=True):
-    """Entity description for a sensor."""
-
-    native_value: StateType | None = None
-
-
-SENSORS: tuple[SyntheticSensorEntityDescription, ...] = (
-    SyntheticSensorEntityDescription(
-        key="generic",
-        state_class=SensorStateClass.MEASUREMENT,
-        native_value=0,
-    ),
-    SyntheticSensorEntityDescription(
-        key="temperature",
-        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_value=20,
-    ),
-    SyntheticSensorEntityDescription(
-        key="humidity",
-        native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.HUMIDITY,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_value=45,
-    ),
-    SyntheticSensorEntityDescription(
-        key="energy",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        native_value=1,
-    ),
-    SyntheticSensorEntityDescription(
-        key="battery",
-        native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY,
-        state_class=SensorStateClass.MEASUREMENT,
-        native_value=90,
-    ),
-)
-SENSOR_MAP = {desc.key: desc for desc in SENSORS}
-
-
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
 ) -> None:
@@ -73,7 +27,7 @@ async def async_setup_entry(
 
     synthetic_home: ParsedHome = hass.data[DOMAIN][entry.entry_id]
     async_add_devices(
-        SyntheticHomeSensor(device, SENSOR_MAP[entity.entity_key], **entity.attributes)
+        SyntheticHomeSensor(device, entity.entity_key, **entity.attributes)
         for device in synthetic_home.devices
         for entity in device.entities
         if entity.platform == SENSOR_DOMAIN
@@ -86,16 +40,22 @@ class SyntheticHomeSensor(SyntheticDeviceEntity, SensorEntity):
     def __init__(
         self,
         device: ParsedDevice,
-        entity_desc: SyntheticSensorEntityDescription,
+        key: str,
         *,
+        device_class: SensorDeviceClass | None = None,
+        state_class: SensorStateClass | None = None,
         native_value: StateType | None = None,
+        state: StateType | None = None,
         native_unit_of_measurement: str | None = None
     ) -> None:
         """Initialize SyntheticHomeSensor."""
-        super().__init__(device, entity_desc.key)
-        self._attr_name = entity_desc.key.capitalize()
-        self.entity_description = entity_desc
-        self._attr_native_value = native_value or entity_desc.native_value
-        self._attr_native_unit_of_measurement = (
-            native_unit_of_measurement or entity_desc.native_unit_of_measurement
-        )
+        super().__init__(device, key)
+        self._attr_name = key.capitalize()
+        if device_class:
+            self._attr_device_class = device_class
+        if state_class:
+            self._attr_state_class = state_class
+        if native_value or state:
+            self._attr_native_value = native_value or state
+        if native_unit_of_measurement:
+            self._attr_native_unit_of_measurement = native_unit_of_measurement

--- a/custom_components/synthetic_home/services.py
+++ b/custom_components/synthetic_home/services.py
@@ -13,9 +13,9 @@ from .const import (
     DOMAIN,
     ATTR_AREA_NAME,
     ATTR_DEVICE_NAME,
-    ATTR_RESTORABLE_ATTRIBUTES_KEY,
+    ATTR_DEVICE_STATE_KEY,
     ATTR_CONFIG_ENTRY_ID,
-    DATA_RESTORABLE_ATTRIBUTES,
+    DATA_DEVICE_STATES,
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -35,18 +35,18 @@ def async_register_services(hass: HomeAssistant) -> None:
         entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
         area_name = call.data.get(ATTR_AREA_NAME)
         device_name = call.data[ATTR_DEVICE_NAME]
-        restorable_attribute_key = call.data[ATTR_RESTORABLE_ATTRIBUTES_KEY]
+        device_state_key = call.data[ATTR_DEVICE_STATE_KEY]
 
-        state_data = hass.data[DOMAIN][DATA_RESTORABLE_ATTRIBUTES].get(entry_id, {})
-        state_data[(area_name, device_name)] = restorable_attribute_key
-        hass.data[DOMAIN][DATA_RESTORABLE_ATTRIBUTES][entry_id] = state_data
+        state_data = hass.data[DOMAIN][DATA_DEVICE_STATES].get(entry_id, {})
+        state_data[(area_name, device_name)] = device_state_key
+        hass.data[DOMAIN][DATA_DEVICE_STATES][entry_id] = state_data
 
         await hass.config_entries.async_reload(entry_id)
 
     async def async_clear_synthetic_device_state(call: ServiceCall) -> None:
         """Reset the device state."""
         entry_id = call.data[ATTR_CONFIG_ENTRY_ID]
-        hass.data[DOMAIN][DATA_RESTORABLE_ATTRIBUTES][entry_id] = {}
+        hass.data[DOMAIN][DATA_DEVICE_STATES][entry_id] = {}
         await hass.config_entries.async_reload(entry_id)
 
     hass.services.async_register(
@@ -58,7 +58,7 @@ def async_register_services(hass: HomeAssistant) -> None:
                 vol.Required(ATTR_CONFIG_ENTRY_ID): cv.string,
                 vol.Optional(ATTR_AREA_NAME): cv.string,
                 vol.Required(ATTR_DEVICE_NAME): cv.string,
-                vol.Required(ATTR_RESTORABLE_ATTRIBUTES_KEY): cv.string,
+                vol.Required(ATTR_DEVICE_STATE_KEY): cv.string,
             }
         ),
     )

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ pytest==8.2.1
 ruff==0.4.4
 
 # Home Assistant testing dependencies
-pytest-asyncio==0.23.7
+pytest-asyncio==0.23.6
 pytest-homeassistant-custom-component==0.13.123
 syrupy==4.6.1
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,4 +17,4 @@ home-assistant-intents>=2024.4.3
 voluptuous-stubs==0.1.1
 
 mashumaro==3.13
-synthetic-home==0.1.0
+synthetic-home==2.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,12 +3,12 @@ black==24.4.2
 mypy==1.10.0
 pip==24.0
 pre-commit==3.7.1
-pytest==8.2.1
+pytest==8.1.1
 ruff==0.4.4
 
 # Home Assistant testing dependencies
 pytest-asyncio==0.23.6
-pytest-homeassistant-custom-component==0.13.123
+pytest-homeassistant-custom-component==0.13.124
 syrupy==4.6.1
 
 # Component dependencies

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from custom_components.synthetic_home.const import (
     DOMAIN,
     CONF_FILENAME,
     ATTR_AREA_NAME,
-    ATTR_RESTORABLE_ATTRIBUTES_KEY,
+    ATTR_DEVICE_STATE_KEY,
     ATTR_DEVICE_NAME,
     ATTR_CONFIG_ENTRY_ID,
 )
@@ -112,7 +112,7 @@ async def restore_state(
     config_entry: MockConfigEntry,
     area_name: str,
     device_name: str,
-    restorable_attributes_key: str,
+    device_state_key: str,
 ) -> None:
     """Restore the specified pre-canned state."""
     await hass.services.async_call(
@@ -122,7 +122,7 @@ async def restore_state(
             ATTR_CONFIG_ENTRY_ID: config_entry.entry_id,
             ATTR_DEVICE_NAME: device_name,
             ATTR_AREA_NAME: area_name,
-            ATTR_RESTORABLE_ATTRIBUTES_KEY: restorable_attributes_key,
+            ATTR_DEVICE_STATE_KEY: device_state_key,
         },
         blocking=True,
     )

--- a/tests/fixtures/heat-pump-example.yaml
+++ b/tests/fixtures/heat-pump-example.yaml
@@ -2,13 +2,16 @@
 name: Family Farmhouse
 devices:
   Family room:
-  - name: Family room
-    device_type: heat-pump
-    unique_id: d4df546410f90f1c1d9be6a8443b8ec6
-    device_info:
-      model: Thermostat
-      manufacturer: Nest
-      sw_version: 1.0.0
-    attributes:
-      unit_of_measurement: °F
-      current_temperature: 60
+    - name: Family room
+      device_type: heat-pump
+      unique_id: d4df546410f90f1c1d9be6a8443b8ec6
+      device_info:
+        model: Thermostat
+        manufacturer: Nest
+        sw_version: 1.0.0
+      device_state:
+        climate.heat-pump:
+          unit_of_measurement: °F
+          current_temperature: 60
+          target_temperature: 60
+        sensor.temperature: 60

--- a/tests/fixtures/hvac-example.yaml
+++ b/tests/fixtures/hvac-example.yaml
@@ -9,6 +9,10 @@ devices:
         model: Thermostat
         manufacturer: Nest
         sw_version: 1.0.0
-      attributes:
-        unit_of_measurement: °F
-        current_temperature: 62
+      device_state:
+        climate.hvac:
+          unit_of_measurement: °F
+          current_temperature: 62
+        sensor.temperature:
+          native_value: 62
+          native_unit_of_measurement: °F

--- a/tests/fixtures/light-dimmable.yaml
+++ b/tests/fixtures/light-dimmable.yaml
@@ -2,7 +2,8 @@
 name: Family Farmhouse
 devices:
   Family Room:
-  - name: Family Room
-    device_type: light-dimmable
-    attributes:
-      brightness: 30
+    - name: Family Room
+      device_type: light-dimmable
+      device_state:
+        light.light-dimmable:
+          brightness: 30

--- a/tests/fixtures/light-rgbw.yaml
+++ b/tests/fixtures/light-rgbw.yaml
@@ -2,7 +2,8 @@
 name: Family Farmhouse
 devices:
   Family Room:
-  - name: Family Room
-    device_type: light-rgbw
-    attributes:
-      rgbw_color: [255, 255, 0, 255]
+    - name: Family Room
+      device_type: light-rgbw
+      device_state:
+        light.light-rgbw:
+          rgbw_color: [255, 255, 0, 255]

--- a/tests/fixtures/motion-sensor-example.yaml
+++ b/tests/fixtures/motion-sensor-example.yaml
@@ -4,5 +4,4 @@ devices:
   Front Yard:
     - name: Front Yard Motion
       device_type: motion-sensor
-      attributes:
-        is_on: True
+      device_state: "on"

--- a/tests/fixtures/weather-example.yaml
+++ b/tests/fixtures/weather-example.yaml
@@ -5,19 +5,18 @@ services:
     device_type: weather-service
     device_info:
       manufacturer: AccuWeather
-    restorable_attribute_keys:
-      - fair
-    attributes:
-      daily_forecast:
-        - cloudy
-        - rainy
-      hourly_forecast:
-        - fair
-        - fair
-        - cloudy
-        - cloudy
-      twice_daily_forecast:
-        - fair
-        - cloudy
-        - rainy
-        - cloudy
+    device_state:
+      weather.weather:
+        daily_forecast:
+          - cloudy
+          - rainy
+        hourly_forecast:
+          - fair
+          - fair
+          - cloudy
+          - cloudy
+        twice_daily_forecast:
+          - fair
+          - cloudy
+          - rainy
+          - cloudy

--- a/tests/snapshots/test_binary_sensor.ambr
+++ b/tests/snapshots/test_binary_sensor.ambr
@@ -15,7 +15,7 @@
 # ---
 # name: test_evaluation_states[tests/fixtures/camera-example.yaml-person-detected]
   dict({
-    'binary_sensor.outdoor_camera_motion': 'on',
+    'binary_sensor.outdoor_camera_motion': 'off',
     'binary_sensor.outdoor_camera_person': 'on',
     'binary_sensor.outdoor_camera_sound': 'off',
   })

--- a/tests/snapshots/test_climate.ambr
+++ b/tests/snapshots/test_climate.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_hvac_restorable_attributes[tests/fixtures/hvac-example.yaml-cooling]
+# name: test_hvac_device_state[tests/fixtures/hvac-example.yaml-cooling]
   tuple(
     'cool',
     ReadOnlyDict({
@@ -13,10 +13,10 @@
       'friendly_name': 'Family Room',
       'hvac_action': 'cooling',
       'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-        <HVACMode.AUTO: 'auto'>,
+        'off',
+        'cool',
+        'heat',
+        'auto',
       ]),
       'max_temp': 35,
       'min_temp': 7,
@@ -26,9 +26,9 @@
     }),
   )
 # ---
-# name: test_hvac_restorable_attributes[tests/fixtures/hvac-example.yaml-off]
+# name: test_hvac_device_state[tests/fixtures/hvac-example.yaml-off]
   tuple(
-    'cool',
+    'off',
     ReadOnlyDict({
       'current_temperature': 22,
       'fan_mode': None,
@@ -40,10 +40,10 @@
       'friendly_name': 'Family Room',
       'hvac_action': 'off',
       'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-        <HVACMode.AUTO: 'auto'>,
+        'off',
+        'cool',
+        'heat',
+        'auto',
       ]),
       'max_temp': 35,
       'min_temp': 7,
@@ -53,7 +53,7 @@
     }),
   )
 # ---
-# name: test_hvac_restorable_attributes[tests/fixtures/hvac-example.yaml-very-low]
+# name: test_hvac_device_state[tests/fixtures/hvac-example.yaml-very-low]
   tuple(
     'cool',
     ReadOnlyDict({
@@ -67,10 +67,10 @@
       'friendly_name': 'Family Room',
       'hvac_action': 'cooling',
       'hvac_modes': list([
-        <HVACMode.OFF: 'off'>,
-        <HVACMode.COOL: 'cool'>,
-        <HVACMode.HEAT: 'heat'>,
-        <HVACMode.AUTO: 'auto'>,
+        'off',
+        'cool',
+        'heat',
+        'auto',
       ]),
       'max_temp': 35,
       'min_temp': 7,

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -44,7 +44,7 @@ async def test_motion_sensor(hass: HomeAssistant, setup_integration: None) -> No
 @pytest.mark.parametrize(
     ("config_yaml_fixture"), [(f"{FIXTURES}/smart-lock-example.yaml")]
 )
-async def tests_smart_lock(hass: HomeAssistant, setup_integration: None) -> None:
+async def test_smart_lock(hass: HomeAssistant, setup_integration: None) -> None:
     """Test a binary sensors for a smart lock."""
 
     state = hass.states.get("binary_sensor.front_door_lock")
@@ -103,10 +103,10 @@ async def test_window_sensor(hass: HomeAssistant, setup_integration: None) -> No
 
 
 @pytest.mark.parametrize(
-    ("config_yaml_fixture", "restorable_attributes_key"),
+    ("config_yaml_fixture", "device_state"),
     [
-        (f"{FIXTURES}/camera-example.yaml", attribute_key)
-        for attribute_key in (
+        (f"{FIXTURES}/camera-example.yaml", device_state)
+        for device_state in (
             "idle",
             "person-detected",
             "sound-detected",
@@ -118,14 +118,19 @@ async def test_evaluation_states(
     hass: HomeAssistant,
     setup_integration: None,
     config_entry: MockConfigEntry,
-    restorable_attributes_key: str,
+    device_state: str,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the loading evaluation states for a specific device."""
 
-    await restore_state(
-        hass, config_entry, "Backyard", "Outdoor Camera", restorable_attributes_key
-    )
+    for entity in (
+        "binary_sensor.outdoor_camera_motion",
+        "binary_sensor.outdoor_camera_person",
+        "binary_sensor.outdoor_camera_sound",
+    ):
+        assert hass.states.get(entity), f"Entity {entity} not found"
+
+    await restore_state(hass, config_entry, "Backyard", "Outdoor Camera", device_state)
     states = {
         entity: hass.states.get(entity).state
         for entity in (

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -37,13 +37,13 @@ async def test_climate_hvac_entity(
 
     state = hass.states.get(TEST_ENTITY)
     assert state
-    assert state.state == "cool"
+    assert state.state == "off"
     assert state.attributes == {
         "friendly_name": "Family Room",
         "current_temperature": 16.7,
         "fan_mode": None,
         "fan_modes": ["low", "high", "off"],
-        "hvac_action": "cooling",
+        "hvac_action": "off",
         "hvac_modes": ["off", "cool", "heat", "auto"],
         "max_temp": 35,
         "min_temp": 7,
@@ -87,13 +87,13 @@ async def test_heat_pump(
 
     state = hass.states.get(test_entity)
     assert state
-    assert state.state == "heat"
+    assert state.state == "off"
     assert state.attributes == {
         "friendly_name": "Family Room",
         "current_temperature": 15.6,
         "fan_mode": None,
         "fan_modes": ["low", "high", "off"],
-        "hvac_action": "heating",
+        "hvac_action": "off",
         "hvac_modes": ["heat", "off"],
         "max_temp": 35,
         "min_temp": 7,
@@ -115,24 +115,22 @@ async def test_heat_pump(
 
 
 @pytest.mark.parametrize(
-    ("config_yaml_fixture", "restorable_attributes_key"),
+    ("config_yaml_fixture", "device_state"),
     [
-        (f"{FIXTURES}/hvac-example.yaml", attribute_key)
-        for attribute_key in ("cooling", "very-low", "off")
+        (f"{FIXTURES}/hvac-example.yaml", device_state)
+        for device_state in ("cooling", "very-low", "off")
     ],
 )
-async def test_hvac_restorable_attributes(
+async def test_hvac_device_state(
     hass: HomeAssistant,
     setup_integration: None,
     config_entry: MockConfigEntry,
-    restorable_attributes_key: str,
+    device_state: str,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test an HVAC device with restorable state."""
 
-    await restore_state(
-        hass, config_entry, "Family room", "Family room", restorable_attributes_key
-    )
+    await restore_state(hass, config_entry, "Family room", "Family room", device_state)
     state = hass.states.get(TEST_ENTITY)
     assert state
     assert (state.state, state.attributes) == snapshot


### PR DESCRIPTION
The primary wins are:
- move all the synthetic home configuration out of python into yaml.
- simplify how device states are specified