### PR TITLE
Add calendar support

### DIFF
--- a/custom_components/synthetic_home/calendar.py
+++ b/custom_components/synthetic_home/calendar.py
@@ -1,0 +1,126 @@
+"""Calendar platform for Synthetic Home."""
+
+import datetime
+import logging
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.components.calendar import (
+    CalendarEntity,
+    CalendarEntityFeature,
+    CalendarEvent,
+    DOMAIN as CALENDAR_DOMAIN,
+)
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .entity import SyntheticEntity
+from .model import ParsedEntity, filter_attributes
+
+_LOGGER = logging.getLogger(__name__)
+
+SUPPORTED_ATTRIBUTES = set(
+    {
+        "supported_features",
+        "events",
+    }
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_devices: AddEntitiesCallback
+) -> None:
+    """Set up calendar platform."""
+    synthetic_home = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_devices(
+        SyntheticCalendarEntity(
+            entity, **filter_attributes(entity, SUPPORTED_ATTRIBUTES)
+        )
+        for entity in synthetic_home.entities
+        if entity.platform == CALENDAR_DOMAIN
+    )
+
+
+def parse_date_or_datetime(value: str) -> datetime.date | datetime.datetime:
+    """Parse a date or datetime value from an isoformat string."""
+    if len(value) > 10 or "T" in value:
+        return datetime.datetime.fromisoformat(value)
+    return datetime.date.fromisoformat(value)
+
+
+DATETIME_FIELDS = {
+    "start": "start",
+    "end": "end",
+    "dtstart": "start",
+    "dtend": "end",
+}
+
+
+def create_event(attributes: dict[str, Any]) -> CalendarEvent:
+    """Create a calendar event from the specified attributes."""
+    fields = {}
+    for attribute in ("summary", "description", "location"):
+        if value := attributes.get(attribute):
+            fields[attribute] = value
+    for from_field, to_field in DATETIME_FIELDS.items():
+        if value := attributes.get(from_field):
+            if isinstance(value, datetime.datetime) or isinstance(value, datetime.date):
+                fields[to_field] = value
+            else:
+                fields[to_field] = parse_date_or_datetime(value)
+    _LOGGER.debug("create_event1=%s", attributes)
+    _LOGGER.debug("create_event2=%s", fields)
+    return CalendarEvent(**fields)
+
+
+class SyntheticCalendarEntity(SyntheticEntity, CalendarEntity):
+    """synthetic_home calendar class."""
+
+    _attr_reports_position = False
+
+    def __init__(
+        self,
+        entity: ParsedEntity,
+        *,
+        supported_features: CalendarEntityFeature | None = None,
+        events: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Initialize the SyntheticCalendarEntity."""
+        super().__init__(entity)
+        if supported_features is not None:
+            self._attr_supported_features = (
+                CalendarEntityFeature(0) | supported_features
+            )
+        self._events = [create_event(event) for event in events or []]
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        """Get the nextactive or upcoming calendar event."""
+        now = dt_util.now()
+        for event in self._events:
+            if event.end_datetime_local < now:
+                return event
+        return None
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime.datetime,
+        end_date: datetime.datetime,
+    ) -> list[CalendarEvent]:
+        """Return calendar events within a datetime range."""
+        result = []
+        for event in self._events:
+            if event.end_datetime_local < start_date:
+                continue
+            if end_date < event.start_datetime_local:
+                continue
+            result.append(event)
+        return result
+
+    async def async_create_event(self, **kwargs: Any) -> None:
+        """Add a new event to calendar."""
+        self._events.append(create_event(kwargs))

--- a/custom_components/synthetic_home/model.py
+++ b/custom_components/synthetic_home/model.py
@@ -129,8 +129,6 @@ def parse_attributes(values: NamedAttributes) -> NamedAttributes:
     """Parse special string attributes as constants."""
     result = {}
     for key, value in values.items():
-        _LOGGER.debug("key=%s", key)
-        _LOGGER.debug("value=%s", value)
         new_value: str | int | None = None
         if key == "device_class" or key == "state_class":
             if isinstance(value, str) and "." in value:
@@ -181,7 +179,6 @@ def parse_home_config(config_file: pathlib.Path) -> ParsedHome:
 
     parsed_entities = []
     for inv_entity in inv.entities:
-        _LOGGER.debug("inv.entities=%s", inv.entities)
         device_info: DeviceInfo | None = None
         if inv_entity.device is not None:
             inv_device = inv_device_dict[inv_entity.device]

--- a/custom_components/synthetic_home/todo.py
+++ b/custom_components/synthetic_home/todo.py
@@ -58,7 +58,7 @@ def create_todo_item(attributes: str | dict[str, Any]) -> TodoItem:
 
 
 class SyntheticTodoEntity(SyntheticEntity, TodoListEntity):
-    """synthetic_home fan class."""
+    """synthetic_home todo class."""
 
     _attr_reports_position = False
 
@@ -67,9 +67,9 @@ class SyntheticTodoEntity(SyntheticEntity, TodoListEntity):
         entity: ParsedEntity,
         *,
         supported_features: TodoListEntityFeature | None = None,
-        todo_items: list[dict[str, Any] | str] | None = None,
+        todo_items: list[dict[str, Any]] | None = None,
     ) -> None:
-        """Initialize the SyntheticFan."""
+        """Initialize the SyntheticTodoEntity."""
         super().__init__(entity)
         if supported_features is not None:
             self._attr_supported_features = (

--- a/tests/fixtures/calendar-example.yaml
+++ b/tests/fixtures/calendar-example.yaml
@@ -1,0 +1,18 @@
+---
+areas: []
+devices:
+  - name: Calendar
+    id: calendar
+entities:
+  - name: Personal
+    id: calendar.personal
+    device: calendar
+    attributes:
+      supported_features:
+        - calendar.CalendarEntityFeature.CREATE_EVENT
+        - calendar.CalendarEntityFeature.DELETE_EVENT
+        - calendar.CalendarEntityFeature.UPDATE_EVENT
+      events:
+        - summary: Bastille Day
+          start: 1997-07-14T17:00:00Z
+          end: 1997-07-15T04:00:00Z

--- a/tests/homes/calendar-example.yaml
+++ b/tests/homes/calendar-example.yaml
@@ -1,0 +1,5 @@
+---
+name: Family Farmhouse
+services:
+  - name: Personal
+    device_type: calendar

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,108 @@
+"""Test Synthetic Home calendar."""
+
+import pytest
+from typing import Any
+
+from homeassistant.const import Platform
+from homeassistant.components.calendar import (
+    DOMAIN as CALENDAR_DOMAIN,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+
+from .conftest import FIXTURES
+
+
+@pytest.fixture(name="platforms")
+def mock_platforms() -> list[Platform]:
+    """Set up platform."""
+    return [Platform.CALENDAR]
+
+
+@pytest.mark.parametrize(
+    ("config_yaml_fixture", "test_entity"),
+    [(f"{FIXTURES}/calendar-example.yaml", "calendar.personal")],
+)
+async def test_calendar(
+    hass: HomeAssistant, setup_integration: None, test_entity: str
+) -> None:
+    """Test calendar."""
+
+    async def get_events(**kwargs: Any) -> dict[str, Any]:
+        response = await hass.services.async_call(
+            CALENDAR_DOMAIN,
+            "get_events",
+            service_data={
+                ATTR_ENTITY_ID: test_entity,
+                "duration": "24:00",  # 1 day
+                **kwargs,
+            },
+            blocking=True,
+            return_response=True,
+        )
+        return response
+
+    state = hass.states.get(test_entity)
+    assert state
+    assert state.state == "off"
+    assert state.attributes == {
+        "friendly_name": "Personal",
+        "all_day": False,
+        "description": "",
+        "message": "Bastille Day",
+        "location": "",
+        "start_time": "1997-07-14 10:00:00",
+        "end_time": "1997-07-14 21:00:00",
+        "supported_features": 7,
+    }
+
+    response = await get_events()
+    assert response == {
+        "calendar.personal": {
+            "events": [],
+        }
+    }
+    response = await get_events(start_date_time="1997-07-14 00:00:00")
+    assert response == {
+        "calendar.personal": {
+            "events": [
+                {
+                    "summary": "Bastille Day",
+                    "start": "1997-07-14T17:00:00+00:00",
+                    "end": "1997-07-15T04:00:00+00:00",
+                },
+            ],
+        }
+    }
+    response = await get_events(start_date_time="1997-07-15 00:00:00")
+    assert response == {
+        "calendar.personal": {
+            "events": [],
+        }
+    }
+
+    await hass.services.async_call(
+        CALENDAR_DOMAIN,
+        "create_event",
+        service_data={
+            ATTR_ENTITY_ID: test_entity,
+            "summary": "New item",
+            "start_date": "2025-04-01",
+            "end_date": "2025-04-02",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    response = await get_events(start_date_time="2025-04-01 00:00:00")
+    assert response == {
+        "calendar.personal": {
+            "events": [
+                {
+                    "summary": "New item",
+                    "start": "2025-04-01",
+                    "end": "2025-04-02",
+                },
+            ],
+        }
+    }


### PR DESCRIPTION
Add support for synthetic calendars and calendar events

Here is an example fixture:

```yaml
---
areas: []
devices:
  - name: Personal
    id: calendar
entities:
  - name: Personal
    id: calendar.personal
    device: calendar
    attributes:
      supported_features:
        - calendar.CalendarEntityFeature.CREATE_EVENT
      events:
        - summary: Bastille Day
          start: 1997-07-14T17:00:00Z
          end: 1997-07-15T04:00:00Z
```